### PR TITLE
Added the location of the ITF data description in providers.yaml

### DIFF
--- a/providers.yaml
+++ b/providers.yaml
@@ -42,6 +42,14 @@
   files:
   - https://raw.githubusercontent.com/janstre/EDITS_metadataTest/main/MISO2_metadata_example.yaml
 
+- id: itf_mt
+  contact:
+    name: Mallory Trouvé
+    email: mallory.trouve@itf-oecd.org
+    github: MalloryTrouve
+  files:
+  - https://github.com/MalloryTrouve/EDITS_ITF_Metadata/blob/main/ITF_GUP_output.yaml
+
 # Demonstration descriptions from an earlier prototype
 #
 # - id: demo

--- a/providers.yaml
+++ b/providers.yaml
@@ -42,13 +42,13 @@
   files:
   - https://raw.githubusercontent.com/janstre/EDITS_metadataTest/main/MISO2_metadata_example.yaml
 
-- id: itf_mt
+- id: itf-oecd
   contact:
     name: Mallory Trouvé
     email: mallory.trouve@itf-oecd.org
     github: MalloryTrouve
   files:
-  - https://github.com/MalloryTrouve/EDITS_ITF_Metadata/blob/main/ITF_GUP_output.yaml
+  - https://raw.githubusercontent.com/MalloryTrouve/EDITS_ITF_Metadata/main/ITF_GUP_output.yaml
 
 # Demonstration descriptions from an earlier prototype
 #


### PR DESCRIPTION
This PR adds the location of the ITF data description in the providers.yaml file and closes issue [#3 ](https://github.com/iiasa/edits-data/issues/3). Thank you @MalloryTrouve!